### PR TITLE
Fixed DiscordRPC being never shut down

### DIFF
--- a/discord-rpc-vs/DiscordRPCVSPackage.cs
+++ b/discord-rpc-vs/DiscordRPCVSPackage.cs
@@ -206,6 +206,16 @@ namespace discord_rpc_vs
             }
         }
 
+        /// <summary>
+        /// Called to ask the package if the shell can be closed. By default this method returns canClose as true and S_OK.
+        /// </summary>
+        /// <param name="canClose">Returns true if the shell can be closed, otherwise false.</param>
+        /// <returns>S_OK(0) if the method succeeded, otherwise an error code.</returns>
+        protected override int QueryClose(out bool canClose)
+        {
+            DiscordRPC.Shutdown();
+            return base.QueryClose(out canClose);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
Noticed the rich presence staying even after I closed Visual Studio, then saw DiscordRPC.Shutdown is never used in the code. Rich presence connection should be terminated when Visual Studio is closed now.

Sorry for the poor documentation of QueryClose as I copypasted it from [here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.package.queryclose?view=visualstudiosdk-2017).